### PR TITLE
Setting datatypes to be consistent with the other coordinate descent variables

### DIFF
--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -245,6 +245,7 @@ function StatsBase.fit{T<:AbstractFloat,V<:FPVector}(::Type{LassoPath},
     coefitr = randomize ? RandomCoefficientIterator() : (1:0)
     cd = naivealgorithm ? NaiveCoordinateDescent{T,intercept,typeof(X),typeof(coefitr)}(X, α, maxncoef, tol, coefitr) :
                           CovarianceCoordinateDescent{T,intercept,typeof(X),typeof(coefitr)}(X, α, maxncoef, tol, coefitr)
+
     # GLM response initialization
     autoλ = λ == nothing
     wts .*= convert(T, 1/sum(wts))

--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -237,6 +237,7 @@ function StatsBase.fit{T<:AbstractFloat,V<:FPVector}(::Type{LassoPath},
     else
         Xnorm = T[]
     end
+
     # Lasso initialization
     α = convert(T, α)
     tol = convert(T, 1e-7)

--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -237,14 +237,13 @@ function StatsBase.fit{T<:AbstractFloat,V<:FPVector}(::Type{LassoPath},
     else
         Xnorm = T[]
     end
-
     # Lasso initialization
     α = convert(T, α)
+    tol = convert(T, 1e-7)
     λminratio = convert(T, λminratio)
     coefitr = randomize ? RandomCoefficientIterator() : (1:0)
-    cd = naivealgorithm ? NaiveCoordinateDescent{T,intercept,typeof(X),typeof(coefitr)}(X, α, maxncoef, 1e-7, coefitr) :
-                          CovarianceCoordinateDescent{T,intercept,typeof(X),typeof(coefitr)}(X, α, maxncoef, 1e-7, coefitr)
-
+    cd = naivealgorithm ? NaiveCoordinateDescent{T,intercept,typeof(X),typeof(coefitr)}(X, α, maxncoef, tol, coefitr) :
+                          CovarianceCoordinateDescent{T,intercept,typeof(X),typeof(coefitr)}(X, α, maxncoef, tol, coefitr)
     # GLM response initialization
     autoλ = λ == nothing
     wts .*= convert(T, 1/sum(wts))

--- a/src/coordinate_descent.jl
+++ b/src/coordinate_descent.jl
@@ -567,7 +567,9 @@ end
 function cdfit!{T}(coef::SparseCoefficients{T}, cd::CoordinateDescent{T}, λ, criterion)
     maxiter = cd.maxiter
     tol = cd.tol
+    α = cd.α
     n = size(cd.X, 1)
+
     obj = convert(T, Inf)
     objold = convert(T, Inf)
     dev = convert(T, Inf)

--- a/src/coordinate_descent.jl
+++ b/src/coordinate_descent.jl
@@ -568,7 +568,6 @@ function cdfit!{T}(coef::SparseCoefficients{T}, cd::CoordinateDescent{T}, λ, cr
     maxiter = cd.maxiter
     tol = cd.tol
     n = size(cd.X, 1)
-
     obj = convert(T, Inf)
     objold = convert(T, Inf)
     dev = convert(T, Inf)
@@ -682,24 +681,21 @@ function StatsBase.fit!{S<:GeneralizedLinearModel,T}(path::LassoPath{S,T}; verbo
                 # Compute working response
                 wrkresp!(scratchmu, eta, wrkresid, offset)
                 wrkwt = wrkwt!(r)
-
                 # Run coordinate descent inner loop
                 niter += cdfit!(newcoef, update!(cd, newcoef, scratchmu, wrkwt), curλ, criterion)
                 b0 = intercept(newcoef, cd)
-
                 # Update GLM and get deviance
                 updatemu!(r, linpred!(scratchmu, cd, newcoef, b0))
-
                 # Compute Elastic Net objective
                 objold = obj
                 dev = deviance(r)
                 obj = dev/2 + curλ*P(α, newcoef)
 
                 if obj > objold + length(scratchmu)*eps(objold)
-                    f = 1.0
+                    f = convert(T, 1.)
                     b0diff = b0 - oldb0
                     while obj > objold
-                        f /= 2.; f > minStepFac || error("step-halving failed at beta = $(newcoef)")
+                        f /= convert(T, 2.); f > minStepFac || error("step-halving failed at beta = $(newcoef)")
                         for icoef = 1:nnz(newcoef)
                             oldcoefval = icoef > nnz(oldcoef) ? zero(T) : oldcoef.coef[icoef]
                             newcoef.coef[icoef] = oldcoefval+f*(newcoef.coef[icoef] - oldcoefval)

--- a/src/coordinate_descent.jl
+++ b/src/coordinate_descent.jl
@@ -683,11 +683,14 @@ function StatsBase.fit!{S<:GeneralizedLinearModel,T}(path::LassoPath{S,T}; verbo
                 # Compute working response
                 wrkresp!(scratchmu, eta, wrkresid, offset)
                 wrkwt = wrkwt!(r)
+
                 # Run coordinate descent inner loop
                 niter += cdfit!(newcoef, update!(cd, newcoef, scratchmu, wrkwt), curλ, criterion)
                 b0 = intercept(newcoef, cd)
+
                 # Update GLM and get deviance
                 updatemu!(r, linpred!(scratchmu, cd, newcoef, b0))
+
                 # Compute Elastic Net objective
                 objold = obj
                 dev = deviance(r)


### PR DESCRIPTION
Without this change, there will only be matching constructors for NaiveCoordinateDescent and CovarianceCoordinateDescent when X contains Float64 values.
