### PR TITLE
fix bug in temporary storage aliasing

### DIFF
--- a/src/TrendFiltering.jl
+++ b/src/TrendFiltering.jl
@@ -156,8 +156,8 @@ function StatsBase.fit{T}(::Type{TrendFilter}, y::AbstractVector{T}, order, λ; 
     Dk = DifferenceMatrix{T}(order-1, length(y))
     β = zeros(T, length(y))
     u = zeros(T, size(Dk, 1))
-    Dkp1β = zeros(T, size(Dkp1, 1))
-    Dkβ = pointer_to_array(pointer(Dkp1β), size(Dk, 1))
+    Dkβ = zeros(T, size(Dk, 1))
+    Dkp1β = pointer_to_array(pointer(Dkβ), size(Dkp1, 1))
     tf = TrendFilter(Dkp1, Dk, Dk'Dk, β, u, Dkβ, Dkp1β, fit(FusedLasso, Dkβ, λ; dofit=false), -1)
     dofit && fit!(tf, y, λ; args...)
     return tf


### PR DESCRIPTION
Hello and thanks a lot for what is possibly my favorite Julia package!

Unless I am mistaken, there was a small bug introduced with the pointer access. The last element of `Dkβ` was stored outside the actual array, since `size(Dkp1,1) == size(Dk,1) - 1` 

On a related note, is this pointer business still necessary for high performance? Or could one of the newer language constructs (such as SubArrays) also achieve the same result?